### PR TITLE
Revert "[#26] Implement Dynamic Wordmark for Theme Modes (#27)"

### DIFF
--- a/components/site-header.tsx
+++ b/components/site-header.tsx
@@ -1,30 +1,16 @@
-"use client";
 import Link from "next/link";
 import { ThemeToggle } from "./theme-toggle";
 import Image from "next/image";
-import { useTheme } from 'next-themes';
-import { useState, useEffect } from 'react';
-import { User } from '@supabase/supabase-js';
-import { createClient } from "@/utils/supabase/client"; 
+import { createClient } from "@/utils/supabase/server";
 import UserNav from "./user-nav";
 import { Button } from "@/components/ui/button";
 
-export function SiteHeader() {
-  const { theme } = useTheme();
-  const [user, setUser] = useState<User | null>(null);
-  const wordmarkSrc = theme === 'light' ? "/wordmark_light.png" : "/wordmark_dark.png";
+export async function SiteHeader() {
+  const supabase = createClient();
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const supabase = createClient();
-      const { data } = await supabase.auth.getUser();
-      if (data) {
-        setUser(data.user);
-      }
-    };
-
-    fetchData();
-  }, []);
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   return (
     <nav>
@@ -33,7 +19,7 @@ export function SiteHeader() {
           <div className="flex items-center">
             <Link href="/">
               <Image
-                src={wordmarkSrc}
+                src="/wordmark_light.png"
                 alt="namebase"
                 width={196}
                 height={64}


### PR DESCRIPTION
This reverts commit 693864226240d6c78858b7a8118ed6175ae7f002.

Also updates so that the logo uses `wordmark_light.png`

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit a1855765fdf1e8d5b2361b593489bf1da833d7da.  | 
|--------|--------|

### Summary:
This PR reverts the dynamic wordmark functionality in `site-header.tsx`, replacing it with a static image and refactoring the `SiteHeader` function to fetch user data directly.

**Key points**:
- Reverted dynamic wordmark functionality in `SiteHeader` function in `site-header.tsx` file
- Replaced dynamic wordmark with static `wordmark_light.png` image
- Removed `useTheme` hook and related logic
- Changed import of `createClient` function to `@/utils/supabase/server`
- Made `SiteHeader` function async and fetched user data directly within it


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
