### PR TITLE
allow users to find domains, generate logos, and create one-pagers for a name of their choosing

### DIFF
--- a/app/new/page.tsx
+++ b/app/new/page.tsx
@@ -1,5 +1,7 @@
 import AuthRefresh from "@/components/auth-refresh";
 import { NameGenerator } from "@/components/name-generator";
+import NewGeneration from "@/components/new-generation";
+import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/server";
 
 export default async function GenerateName({
@@ -18,7 +20,7 @@ export default async function GenerateName({
   if (searchParams && searchParams.ids) {
     const idString = searchParams.ids as string;
     const idRegex = /.{36}/g;
-    idsList = idString.match(idRegex); 
+    idsList = idString.match(idRegex);
 
     const { data, error } = await supabase
       .from("names")
@@ -31,9 +33,8 @@ export default async function GenerateName({
 
   return (
     <div className="w-full px-4">
-      <h1 className="text-2xl font-bold mb-4">Name Generator</h1>
       <AuthRefresh idsList={idsList ?? []} />
-      <NameGenerator user={user} names={names ?? null} />
+      <NewGeneration user={user} names={names} />
     </div>
   );
 }

--- a/components/description.tsx
+++ b/components/description.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { Input } from "./ui/input";
 import Link from "next/link";
 import { Button } from "./ui/button";
+import { v4 as uuidv4 } from "uuid";
 
 export default function Description() {
   const [description, setDescription] = useState("");
@@ -43,8 +44,4 @@ export default function Description() {
       </div>
     </div>
   );
-}
-
-function uuidv4(): string {
-  throw new Error("Function not implemented.");
 }

--- a/components/description.tsx
+++ b/components/description.tsx
@@ -1,40 +1,50 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Input } from "./ui/input";
 import Link from "next/link";
 import { Button } from "./ui/button";
 
 export default function Description() {
-    const [description, setDescription] = useState("");
-  
-    return (
-      <div className="w-full md:w-4/5 flex flex-col md:flex-row items-center gap-4">
-        <Input
-          placeholder="Describe your startup in a few words"
-          className="rounded-md w-full md:w-auto md:flex-grow" 
-          value={description}
-          onChange={(e) => setDescription(e.target.value)}
-          autoFocus
-        />
-        <div className="w-full md:w-auto"> 
-          <Link
-            href={{
-              pathname: "/new",
-              query: { description: description },
+  const [description, setDescription] = useState("");
+
+  useEffect(() => {
+    if (!localStorage.getItem("session_id")) {
+      localStorage.setItem("session_id", uuidv4());
+    }
+  }, []);
+
+  return (
+    <div className="w-full md:w-4/5 flex flex-col md:flex-row items-center gap-4">
+      <Input
+        placeholder="Describe your startup in a few words"
+        className="rounded-md w-full md:w-auto md:flex-grow"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+        autoFocus
+      />
+      <div className="w-full md:w-auto">
+        <Link
+          href={{
+            pathname: "/new",
+            query: { description: description, session_id: localStorage.getItem("session_id") },
+          }}
+        >
+          <Button
+            className="text-lg w-full md:w-auto"
+            style={{
+              background:
+                "linear-gradient(43deg, #4158D0 0%, #C850C0 46%, #FFCC70 100%)",
             }}
           >
-            <Button
-              className="text-lg w-full md:w-auto"  
-              style={{
-                background: "linear-gradient(43deg, #4158D0 0%, #C850C0 46%, #FFCC70 100%)",
-              }}
-            >
-              Get Started
-            </Button>
-          </Link>
-        </div>
+            Get Started
+          </Button>
+        </Link>
       </div>
-    );
-  }
-  
+    </div>
+  );
+}
+
+function uuidv4(): string {
+  throw new Error("Function not implemented.");
+}

--- a/components/name-generator.tsx
+++ b/components/name-generator.tsx
@@ -125,15 +125,14 @@ export function NameGenerator({ user, names }: { user: any; names: any }) {
   const [autoSubmitted, setAutoSubmitted] = useState(false);
 
   useEffect(() => {
-    // Only auto-submit if `queryDescription` is present and the form hasn't been auto-submitted yet
     if (queryDescription && !autoSubmitted) {
       const submitForm = async () => {
         await onSubmit(form.getValues());
-        setAutoSubmitted(true); // Prevent further auto-submissions
+        setAutoSubmitted(true); 
       };
       submitForm();
     }
-  }, [queryDescription, autoSubmitted]); // Now also depends on `autoSubmitted`
+  }, [queryDescription, autoSubmitted]); 
   
 
   async function clear() {
@@ -159,7 +158,6 @@ export function NameGenerator({ user, names }: { user: any; names: any }) {
   }, [names, user]);
 
   async function onSubmit(values: z.infer<typeof formSchema>) {
-    console.log("in on submit");
     setIsLoading(true);
     setNamesList({});
     setIdsList([]);

--- a/components/names-display.tsx
+++ b/components/names-display.tsx
@@ -605,7 +605,7 @@ export function NamesDisplay({
   };
 
   return (
-    <div>
+    <div className="min-h-screen">
       {verticalLayout ? (
         <div className="flex flex-col space-y-4">
           {Object.keys(namesList).map((name, index) => (

--- a/components/names-display.tsx
+++ b/components/names-display.tsx
@@ -107,7 +107,9 @@ export function NamesDisplay({
         setFavoritedNames(favoritedMap);
       }
     }
-    fetchFavoritedStatus();
+    if (user) {
+      fetchFavoritedStatus();
+    }
   }, [namesList, user]);
 
   async function toggleFavoriteName(name: string) {

--- a/components/new-generation.tsx
+++ b/components/new-generation.tsx
@@ -1,0 +1,89 @@
+"use client";
+import { useState } from "react";
+import { NameGenerator } from "./name-generator";
+import { Button } from "./ui/button";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
+import { createClient } from "@/utils/supabase/client";
+import { NamesDisplay } from "./names-display";
+
+export default function NewGeneration({
+  user,
+  names,
+}: {
+  user: any;
+  names: any;
+}) {
+  const [namesList, setNamesList] = useState<{ [name: string]: string }>({});
+  const [inputName, setInputName] = useState<string>("");
+  const [showNamesDisplay, setShowNamesDisplay] = useState<boolean>(false);
+  const supabase = createClient();
+
+  async function addExistingName() {
+    const updatedNamesList: { [name: string]: string } = {};
+    console.log(inputName);
+
+    try {
+      const updates = {
+        name: inputName,
+        created_at: new Date(),
+        created_by: user?.id,
+        session_id: localStorage.getItem("session_id"),
+      };
+      const { data, error } = await supabase
+        .from("names")
+        .insert(updates)
+        .select();
+
+      console.log(data);
+      if (data) {
+        updatedNamesList[data[0].name] = data[0].id;
+        setNamesList(updatedNamesList);
+        setShowNamesDisplay(true); 
+      }
+
+      if (error) {
+        console.error(error);
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  return (
+    <div>
+      <div className="flex justify-between items-center mb-4">
+        <h1 className="text-2xl font-bold">Name Generator</h1>
+        {showNamesDisplay ? (
+          <Button variant="ghost" onClick={() => setShowNamesDisplay(false)}>
+            Back
+          </Button>
+        ) : (
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant="ghost">
+                Already have a name? Skip to the branding.
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="space-y-2">
+              <Input
+                type="text"
+                placeholder="Enter your startup's name"
+                value={inputName}
+                onChange={(e) => setInputName(e.target.value)}
+              />
+              <Button className="w-full" onClick={addExistingName}>
+                Go
+              </Button>
+            </PopoverContent>
+          </Popover>
+        )}
+      </div>
+      {!showNamesDisplay && <NameGenerator user={user} names={names ?? null} />}
+      {showNamesDisplay && (
+        <NamesDisplay namesList={namesList} user={user} verticalLayout={true} />
+      )}
+    </div>
+  );
+}

--- a/components/new-generation.tsx
+++ b/components/new-generation.tsx
@@ -26,7 +26,6 @@ export default function NewGeneration({
   
   async function addExistingName() {
     const updatedNamesList: { [name: string]: string } = {};
-    console.log(inputName);
 
     try {
       const updates = {
@@ -40,18 +39,18 @@ export default function NewGeneration({
         .insert(updates)
         .select();
 
-      console.log(data);
       if (data) {
         updatedNamesList[data[0].name] = data[0].id;
         setNamesList(updatedNamesList);
         setShowNamesDisplay(true); 
+        setInputName("");
       }
 
       if (error) {
         console.error(error);
       }
     } catch (error) {
-      console.log(error);
+      console.error(error);
     }
   }
 

--- a/components/new-generation.tsx
+++ b/components/new-generation.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { NameGenerator } from "./name-generator";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -7,6 +7,7 @@ import { Label } from "./ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { createClient } from "@/utils/supabase/client";
 import { NamesDisplay } from "./names-display";
+import { useSearchParams } from "next/navigation";
 
 export default function NewGeneration({
   user,
@@ -19,7 +20,10 @@ export default function NewGeneration({
   const [inputName, setInputName] = useState<string>("");
   const [showNamesDisplay, setShowNamesDisplay] = useState<boolean>(false);
   const supabase = createClient();
+  const searchParams = useSearchParams();
+  const sessionId = searchParams.get("session_id");
 
+  
   async function addExistingName() {
     const updatedNamesList: { [name: string]: string } = {};
     console.log(inputName);
@@ -29,7 +33,7 @@ export default function NewGeneration({
         name: inputName,
         created_at: new Date(),
         created_by: user?.id,
-        session_id: localStorage.getItem("session_id"),
+        session_id: sessionId,
       };
       const { data, error } = await supabase
         .from("names")
@@ -87,3 +91,7 @@ export default function NewGeneration({
     </div>
   );
 }
+function uuidv4(): string {
+    throw new Error("Function not implemented.");
+}
+


### PR DESCRIPTION
this pull request does the following:
* adds a button to the name generation page to see if a user prefers to use their own name
* has an input for them to put the name
* takes them to the names display card with that name and presents the options to find domains, generate logos, and one pagers

this also restructures the way we get sessionIds so we do it for all users and pass it as a param to the /new page

lastly it restructures the way we do lookups so if someone else has looked up the domain for your name, we don't have to call the api again

<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 37d242edbbb45a4bd971c37c7705f9e52a563573.  | 
|--------|--------|

### Summary:
This PR introduces a feature for users to use their own names for domain, logo, and one-pager generation, optimizes session ID handling, and improves domain lookup efficiency.

**Key points**:
- Added a feature to allow users to use their own names for domain, logo, and one-pager generation.
- Optimized the way session IDs are handled.
- Improved the efficiency of domain lookups by reusing data from previous lookups.
- Changes are spread across multiple files, including `app/new/page.tsx`, `components/description.tsx`, `components/name-generator.tsx`, `components/names-display.tsx`, and `components/new-generation.tsx`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
