### PR TITLE
fix double render bug

### DIFF
--- a/components/name-generator.tsx
+++ b/components/name-generator.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Button } from "@/components/ui/button";
 import {
@@ -120,20 +120,17 @@ export function NameGenerator({ user, names }: { user: any; names: any }) {
   const [isLoading, setIsLoading] = useState(false);
   const [namesList, setNamesList] = useState<{ [name: string]: string }>({});
   const [idsList, setIdsList] = useState<string[]>([]);
-  const [isOwner, setIsOwner] = useState<boolean>(false);
-
-  const [autoSubmitted, setAutoSubmitted] = useState(false);
+  const autoSubmitted = useRef(false);
 
   useEffect(() => {
-    if (queryDescription && !autoSubmitted) {
+    if (queryDescription && !autoSubmitted.current) {
+      autoSubmitted.current = true;
       const submitForm = async () => {
         await onSubmit(form.getValues());
-        setAutoSubmitted(true); 
       };
       submitForm();
     }
-  }, [queryDescription, autoSubmitted]); 
-  
+  }, [queryDescription, autoSubmitted]);
 
   async function clear() {
     form.reset();
@@ -145,9 +142,6 @@ export function NameGenerator({ user, names }: { user: any; names: any }) {
       const updatedNamesList: { [name: string]: string } = {};
       for (const name of names) {
         updatedNamesList[name.name] = name.id;
-        if (user && name.created_by === user.id) {
-          setIsOwner(true);
-        }
       }
       setNamesList(updatedNamesList);
 


### PR DESCRIPTION
ensures that creating a name from the landing page only runs the submit once

<!--
ELLIPSIS_HIDDEN
-->


----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit 3529cce2d596272a21d73c7a52057db53096d3df.  | 
|--------|--------|

### Summary:
This PR fixes a double render bug in the `NameGenerator` component by replacing `useState` with `useRef` for `autoSubmitted` and removing unused `isOwner` state.

**Key points**:
- Replaced `useState` with `useRef` for `autoSubmitted` in `NameGenerator` component.
- Updated `useEffect` hook to use `autoSubmitted.current`.
- Removed `isOwner` state and related code.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
