### PR TITLE
useMemo for session_id

### DIFF
--- a/components/name-generator.tsx
+++ b/components/name-generator.tsx
@@ -136,19 +136,6 @@ export function NameGenerator({ user, names }: { user: any; names: any }) {
     }
   }, [queryDescription, autoSubmitted]);
 
-  /*   const autoSubmitted = useRef(false);
-
-  useEffect(() => {
-    if (queryDescription && !autoSubmitted.current) {
-      autoSubmitted.current = true;
-      const submitForm = async () => {
-        await onSubmit(form.getValues());
-      };
-      submitForm();
-      router.push('/new')
-    }
-  }, [queryDescription, autoSubmitted]); */
-
   async function clear() {
     form.reset();
     setNamesList({});

--- a/components/name-generator.tsx
+++ b/components/name-generator.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import { Button } from "@/components/ui/button";
 import {
@@ -82,7 +82,10 @@ export function NameGenerator({ user, names }: { user: any; names: any }) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryDescription = searchParams.get("description");
-  const sessionId = searchParams.get("session_id");
+  const sessionId = useMemo(
+    () => searchParams.get("session_id") || uuidv4(),
+    [searchParams]
+  );
   const [isScreenWide, setIsScreenWide] = useState(false);
 
   useEffect(() => {
@@ -129,9 +132,22 @@ export function NameGenerator({ user, names }: { user: any; names: any }) {
         await onSubmit(form.getValues());
       };
       submitForm();
-      router.push('/new')
+      router.push(`/new?session_id=${sessionId}`);
     }
   }, [queryDescription, autoSubmitted]);
+
+  /*   const autoSubmitted = useRef(false);
+
+  useEffect(() => {
+    if (queryDescription && !autoSubmitted.current) {
+      autoSubmitted.current = true;
+      const submitForm = async () => {
+        await onSubmit(form.getValues());
+      };
+      submitForm();
+      router.push('/new')
+    }
+  }, [queryDescription, autoSubmitted]); */
 
   async function clear() {
     form.reset();

--- a/components/new-generation.tsx
+++ b/components/new-generation.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { NameGenerator } from "./name-generator";
 import { Button } from "./ui/button";
 import { Input } from "./ui/input";
@@ -21,8 +21,10 @@ export default function NewGeneration({
   const [showNamesDisplay, setShowNamesDisplay] = useState<boolean>(false);
   const supabase = createClient();
   const searchParams = useSearchParams();
-  const sessionId = searchParams.get("session_id");
-
+  const sessionId = useMemo(
+    () => searchParams.get("session_id") || uuidv4(),
+    [searchParams]
+  );
   
   async function addExistingName() {
     const updatedNamesList: { [name: string]: string } = {};


### PR DESCRIPTION
this changes the way we access session_id and keeps it in the query param to fix the bug where you can't generate after the first generation from the landing page

<!--
ELLIPSIS_HIDDEN
-->
----

| <a href="https://ellipsis.dev" target="_blank"><img src="https://avatars.githubusercontent.com/u/80834858?s=400&u=31e596315b0d8f7465b3ee670f25cea677299c96&v=4" alt="Ellipsis" width="30px" height="30px"/></a> | :rocket: This PR description was created by [Ellipsis](https://www.ellipsis.dev) for commit f2483f03ba016031c4bffd72129b7049e117b0fe.  | 
|--------|--------|

### Summary:
This PR modifies the `session_id` access in `NameGenerator` component using `useMemo` hook to fix a bug preventing new generations after the first one from the landing page.

**Key points**:
- Modified `session_id` access in `NameGenerator` component using `useMemo` hook.
- `session_id` is now included in the query parameters when the router pushes to the `/new` route.
- Aimed at fixing a bug preventing new generations after the first one from the landing page.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)

<!--
ELLIPSIS_HIDDEN
-->
